### PR TITLE
updated reference to css selectors in following lines of the Readme:

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ retrieve the desired text.
 ### Iterating over elements
 
 Sometimes we want to get a collection of the same elements, so we can iterate
-over them. For instance, a little further down the [page][] are some of the
+over them. For instance, a little further down the [page][https://flatironschool.com/] are some of the
 courses offered by Flatiron School. We can practice iterating by trying to
 scrape the titles of all courses from these elements.
 
@@ -367,7 +367,7 @@ scrape the titles of all courses from these elements.
 ![courses](https://curriculum-content.s3.amazonaws.com/web-development/ruby/scraping_flatironschool_courses.png)
 
 This time, if we hover over one of the elements containing a course, we'll see
-there are two classes assigned, `inlineMobileLeft-2Yo002`, and `imageTextBlockGrid3-2XAK6G`. Since CSS classes are often shared, we'll use all two to
+there are two classes assigned, `inlineMobileLeft-2Yo002`, and `imageTextBlockGrid2-3jXtmC`. Since CSS classes are often shared, we'll use all two to
 try and get only the content we need:
 
 ```ruby
@@ -377,25 +377,25 @@ require 'open-uri'
 html = open("https://flatironschool.com/")
 doc = Nokogiri::HTML(html)
 
-doc.css(".inlineMobileLeft-2Yo002.imageTextBlockGrid3-2XAK6G")
+doc.css(".inlineMobileLeft-2Yo002.imageTextBlockGrid2-3jXtmC")
 ```
 
 > Notice that each class is listed without spaces!
 > To make sure we only select the three courses in this section and not also other elements that might share the same class name, we will increase the `specificity` of our CSS selector. In order to make our selector more `strict`, we'll target the correct section first and then the elements containing a course. 
 
-This section has the id `2a778efd-1685-5ec6-9e5a-0843d6a88b7b`, and adding that to the final selector will produce: `.css("#2a778efd-1685-5ec6-9e5a-0843d6a88b7b .inlineMobileLeft-2Yo002.imageTextBlockGrid3-2XAK6G")`.
+
 Even though the Nokogiri gem returns a `Nokogiri::XML::NodeSet` (which looks like an Array in Ruby), we can use Ruby methods, such as `.each` and `.collect`,
 to iterate over it.
 
 ```bash
-[#<Nokogiri::XML::Element:0x3fdf31ee8eb4 name="h2" attributes=[#<Nokogiri::XML::Attr:0x3fdf31ee8e28 name="class" value="inlineMobileLeft-2Yo002 imageTextBlockGrid3-2XAK6G">] children=[#<Nokogiri::XML::Text:0x3fdf31ee8900 "\n          $1M in Scholarships for Women\n        ">]>, #<Nokogiri::XML::Element:0x3fdf31ee8748 name="h2" attributes=[#<Nokogiri::XML::Attr:0x3fdf31ee86e4 name="class" value="tout__label heading heading--level-4">] children=[#<Nokogiri::XML::Text:0x3fdf31ee8270 "\n          What Kind of Coding Program is Right for You?\n        ">]>, #<Nokogiri::XML::Element:0x3fdf31ee807c name="h2" attributes=[#<Nokogiri::XML::Attr:0x3fdf31eedfcc name="class" value="tout__label heading heading--level-4">] children=[#<Nokogiri::XML::Text:0x3fdf31eeda90 "\n          Attend an Online Info Session\n        ">]>, #<Nokogiri::XML::Element:0x3fdf31eed8d8 name="h2" attributes=[#<Nokogiri::XML::Attr:0x3fdf31eed860 name="class" value="tout__label heading heading--level-4">] children=[#<Nokogiri::XML::Text:0x3fdf31eed43c "\n          Coding Bootcamp Prep\n        ">]>, #<Nokogiri::XML::Element:0x3fdf31eed284 name="h2" attributes=[#<Nokogiri::XML::Attr:0x3fdf31eed220 name="class" value="tout__label heading heading--level-4">] children=[#<Nokogiri::XML::Text:0x3fdf31eecdc0 "\n          Online Software Engineering\n        ">]>, #<Nokogiri::XML::Element:0x3fdf31eecc1c name="h2" attributes=[#<Nokogiri::XML::Attr:0x3fdf31eecba4 name="class" value="tout__label heading heading--level-4">] children=[#<Nokogiri::XML::Text:0x3fdf31eec744 "\n          Data Science Bootcamp Prep\n        ">]>, #<Nokogiri::XML::Element:0x3fdf31eec5a0 name="h2" attributes=[#<Nokogiri::XML::Attr:0x3fdf31eec53c name="class" value="tout__label heading heading--level-4">] children=[#<Nokogiri::XML::Text:0x3fdf31ef3fbc "\n          Online Data Science\n        ">]>]
+[#<Nokogiri::XML::Element:0x3fdf31ee8eb4 name="h2" attributes=[#<Nokogiri::XML::Attr:0x3fdf31ee8e28 name="class" value="inlineMobileLeft-2Yo002 imageTextBlockGrid2-3jXtmC">] children=[#<Nokogiri::XML::Text:0x3fdf31ee8900 "\n          $1M in Scholarships for Women\n        ">]>, #<Nokogiri::XML::Element:0x3fdf31ee8748 name="h2" attributes=[#<Nokogiri::XML::Attr:0x3fdf31ee86e4 name="class" value="tout__label heading heading--level-4">] children=[#<Nokogiri::XML::Text:0x3fdf31ee8270 "\n          What Kind of Coding Program is Right for You?\n        ">]>, #<Nokogiri::XML::Element:0x3fdf31ee807c name="h2" attributes=[#<Nokogiri::XML::Attr:0x3fdf31eedfcc name="class" value="tout__label heading heading--level-4">] children=[#<Nokogiri::XML::Text:0x3fdf31eeda90 "\n          Attend an Online Info Session\n        ">]>, #<Nokogiri::XML::Element:0x3fdf31eed8d8 name="h2" attributes=[#<Nokogiri::XML::Attr:0x3fdf31eed860 name="class" value="tout__label heading heading--level-4">] children=[#<Nokogiri::XML::Text:0x3fdf31eed43c "\n          Coding Bootcamp Prep\n        ">]>, #<Nokogiri::XML::Element:0x3fdf31eed284 name="h2" attributes=[#<Nokogiri::XML::Attr:0x3fdf31eed220 name="class" value="tout__label heading heading--level-4">] children=[#<Nokogiri::XML::Text:0x3fdf31eecdc0 "\n          Online Software Engineering\n        ">]>, #<Nokogiri::XML::Element:0x3fdf31eecc1c name="h2" attributes=[#<Nokogiri::XML::Attr:0x3fdf31eecba4 name="class" value="tout__label heading heading--level-4">] children=[#<Nokogiri::XML::Text:0x3fdf31eec744 "\n          Data Science Bootcamp Prep\n        ">]>, #<Nokogiri::XML::Element:0x3fdf31eec5a0 name="h2" attributes=[#<Nokogiri::XML::Attr:0x3fdf31eec53c name="class" value="tout__label heading heading--level-4">] children=[#<Nokogiri::XML::Text:0x3fdf31ef3fbc "\n          Online Data Science\n        ">]>]
 ```
 
 Instead of just outputting the results of `doc.css`, if we assign them
 to a variable, we can then iterate over that variable with `.each` and `puts` out each course:
 
 ```ruby
-courses = doc.css("#2a778efd-1685-5ec6-9e5a-0843d6a88b7b .inlineMobileLeft-2Yo002.imageTextBlockGrid3-2XAK6G")
+courses = doc.css(".inlineMobileLeft-2Yo002.imageTextBlockGrid2-3jXtmC")
 
 courses.each do |course|
   puts course.text.strip
@@ -407,7 +407,8 @@ We'd see something like this:
 ```text
 Software EngineeringLaunch your career as a full-stack web developer ...
 Data ScienceOur full-time data science program that gives students ...
-UX/UI DesignLearn the user experience, client management, technical, ...
+Cybersecurity AnalyticsOver 12 intense weeks on campus at Flatiron ...
+Cybersecurity EngineeringFast-track to the skills you need for a new ...
 ```
 
 Not _exactly_ the course listing as it scraped some other content as well - a
@@ -421,24 +422,24 @@ method. In the previous example, we had many `Nokogiri` objects to iterate over.
 Looking at just the first one:
 
 ```ruby
-p doc.css("#2a778efd-1685-5ec6-9e5a-0843d6a88b7b .inlineMobileLeft-2Yo002.imageTextBlockGrid3-2XAK6G")[0]
+p doc.css(".inlineMobileLeft-2Yo002.imageTextBlockGrid2-3jXtmC")[0]
 ```
 
 We get the following:
 
 ```text
-#<Nokogiri::XML::Element:0x3fc3494ba054 name="div" attributes=[#<Nokogiri::XML::Attr:0x3fc3494ba298 name="class" value="inlineMobileLeft-2Yo002 imageTextBlockGrid3-2XAK6G">] children=[#<Nokogiri::XML::Element:0x3fc3494abd88 name="div" attributes=[#<Nokogiri::XML::Attr:0x3fc3494abd24 name="class" value="media-3NKI6- horizontalImageContainer-1a2NpA">]...
+#<Nokogiri::XML::Element:0x3fc3494ba054 name="div" attributes=[#<Nokogiri::XML::Attr:0x3fc3494ba298 name="class" value="inlineMobileLeft-2Yo002 imageTextBlockGrid2-3jXtmC">] children=[#<Nokogiri::XML::Element:0x3fc3494abd88 name="div" attributes=[#<Nokogiri::XML::Attr:0x3fc3494abd24 name="class" value="media-3NKI6- horizontalImageContainer-1a2NpA">]...
 ```
 
 This is an XML element. XML stands for Extensible Markup Language. Just like
 HTML, it is a set of rules for encoding and displaying data on the web.
 
 When we use Nokogiri methods, we get XML elements in return. Looking at the
-output object, we can see it has a `name`, "h2". We can get
+output object, we can see it has a `name`, "div". We can get
 this info directly by adding these to the end of our `doc.css` call:
 
 ```ruby
-p doc.css("#2a778efd-1685-5ec6-9e5a-0843d6a88b7b .inlineMobileLeft-2Yo002.imageTextBlockGrid3-2XAK6G")[0].name
+p doc.css(".inlineMobileLeft-2Yo002.imageTextBlockGrid2-3jXtmC")[0].name
 # => "div"
 ```
 
@@ -449,14 +450,14 @@ classes, but will also return other useful content like `alt` and `src` for
 images.
 
 ```ruby
-p doc.css("#2a778efd-1685-5ec6-9e5a-0843d6a88b7b .inlineMobileLeft-2Yo002.imageTextBlockGrid3-2XAK6G")[0].attributes
+p doc.css(".inlineMobileLeft-2Yo002.imageTextBlockGrid2-3jXtmC")[0].attributes
 ```
 
 Since this example doesn't have any attributes besides the CSS classes, we just
 get back the classes we already know:
 
 ```text
-{"class"=>#<Nokogiri::XML::Attr:0x3fd0e50e1b04 name="class" value="inlineMobileLeft-2Yo002 imageTextBlockGrid3-2XAK6G">}
+{"class"=>#<Nokogiri::XML::Attr:0x3fd0e50e1b04 name="class" value="inlineMobileLeft-2Yo002 imageTextBlockGrid2-3jXtmC">}
 ```
 
 One last but important method to note is `children`. Adding `children` will


### PR DESCRIPTION
add url address to markdown link in line 361
update number of elements from 3 to 2 (line 370)
update css elements (line 370)
update css elements (line 380)
remove line 386 (as ruby-remote-data-practice-scraping lab has done)
update css elements in initial portion of Nokogiri output (line 391).
update css elements (line 398)
update description of returned titles (L-408-411)
update css elements (line 425)
update output example (line 431)
update css elements (line 442)
update css elements (line 453)
update output example (line 460)


The example outputs in 391, 431 were not updated entirely